### PR TITLE
Remove wrong statusbar entry from root config.xml

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -25,9 +25,6 @@
   <preference name="BackupWebStorage" value="none"/>
   <preference name="SplashScreenDelay" value="2000"/>
   <preference name="FadeSplashScreenDuration" value="2000"/>
-  <feature name="StatusBar">
-    <param name="ios-package" onload="true" value="CDVStatusBar"/>
-  </feature>
   <plugin name="cordova-plugin-device" spec="~1.1.3"/>
   <plugin name="cordova-plugin-console" spec="~1.0.4"/>
   <plugin name="cordova-plugin-whitelist" spec="~1.3.0"/>


### PR DESCRIPTION
Feature tags are added by the plugin on the config.xml on plugin install, it shouldn't be on the root config.xml